### PR TITLE
Implement message management actions

### DIFF
--- a/Chattrix.Api/Controllers/ChatController.cs
+++ b/Chattrix.Api/Controllers/ChatController.cs
@@ -15,17 +15,69 @@ public class ChatController : ControllerBase
         _chatService = chatService;
     }
 
-    [HttpGet]
-    public async Task<IEnumerable<ChatMessage>> Get(CancellationToken cancellationToken)
+    [HttpPost("start")]
+    public async Task<ActionResult<Guid>> Start(string user1, string user2, string topic, CancellationToken cancellationToken)
     {
-        return await _chatService.GetMessagesAsync(cancellationToken);
+        var id = await _chatService.StartConversationAsync(user1, user2, topic, cancellationToken);
+        return Ok(id);
     }
 
-    [HttpPost]
-    public async Task<IActionResult> Post(string user, string content, CancellationToken cancellationToken)
+    [HttpGet("{conversationId}")]
+    public Task<IReadOnlyList<ChatMessage>> Get(Guid conversationId, CancellationToken cancellationToken)
     {
-        await _chatService.SendMessageAsync(user, content, cancellationToken);
+        return _chatService.GetMessagesAsync(conversationId, cancellationToken);
+    }
+
+    [HttpPost("{conversationId}")]
+    public async Task<IActionResult> Post(Guid conversationId, string sender, string content, string? fileName, CancellationToken cancellationToken)
+    {
+        await _chatService.SendMessageAsync(conversationId, sender, content, fileName, cancellationToken);
         return Ok();
     }
-}
 
+    [HttpGet("{conversationId}/search")]
+    public Task<IReadOnlyList<ChatMessage>> Search(Guid conversationId, string term, CancellationToken cancellationToken)
+    {
+        return _chatService.SearchAsync(conversationId, term, cancellationToken);
+    }
+
+    [HttpGet("{conversationId}/files")]
+    public Task<IReadOnlyList<string>> Files(Guid conversationId, CancellationToken cancellationToken)
+    {
+        return _chatService.GetFilesAsync(conversationId, cancellationToken);
+    }
+
+    [HttpGet("message/{id}")]
+    public Task<ChatMessage?> GetMessage(Guid id, CancellationToken cancellationToken)
+    {
+        return _chatService.GetMessageAsync(id, cancellationToken);
+    }
+
+    [HttpPut("message/{id}")]
+    public async Task<IActionResult> Put(Guid id, string content, CancellationToken cancellationToken)
+    {
+        await _chatService.UpdateMessageAsync(id, content, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete("message/{id}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        await _chatService.DeleteMessageAsync(id, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPut("message/{id}/delivered")]
+    public async Task<IActionResult> Delivered(Guid id, CancellationToken cancellationToken)
+    {
+        await _chatService.MarkDeliveredAsync(id, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPut("message/{id}/read")]
+    public async Task<IActionResult> Read(Guid id, CancellationToken cancellationToken)
+    {
+        await _chatService.MarkReadAsync(id, cancellationToken);
+        return NoContent();
+    }
+}

--- a/Chattrix.Api/Controllers/UserController.cs
+++ b/Chattrix.Api/Controllers/UserController.cs
@@ -1,0 +1,43 @@
+using Chattrix.Application.Interfaces;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Chattrix.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class UserController : ControllerBase
+{
+    private readonly IUserService _users;
+
+    public UserController(IUserService users)
+    {
+        _users = users;
+    }
+
+    [HttpPost("status")] 
+    public async Task<IActionResult> SetStatus(string user, string status, CancellationToken cancellationToken)
+    {
+        await _users.SetStatusAsync(user, status, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpGet("status/{user}")]
+    public Task<string?> GetStatus(string user, CancellationToken cancellationToken)
+    {
+        return _users.GetStatusAsync(user, cancellationToken);
+    }
+
+    [HttpPost("block")]
+    public async Task<IActionResult> Block(string user, string blocked, CancellationToken cancellationToken)
+    {
+        await _users.BlockAsync(user, blocked, cancellationToken);
+        return NoContent();
+    }
+
+    [HttpPost("unblock")]
+    public async Task<IActionResult> Unblock(string user, string blocked, CancellationToken cancellationToken)
+    {
+        await _users.UnblockAsync(user, blocked, cancellationToken);
+        return NoContent();
+    }
+}

--- a/Chattrix.Application/DependencyInjection.cs
+++ b/Chattrix.Application/DependencyInjection.cs
@@ -8,6 +8,7 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddApplication(this IServiceCollection services)
     {
+        services.AddTransient<IUserService, UserService>();
         services.AddTransient<IChatService, ChatService>();
         return services;
     }

--- a/Chattrix.Application/Interfaces/IChatService.cs
+++ b/Chattrix.Application/Interfaces/IChatService.cs
@@ -4,7 +4,15 @@ namespace Chattrix.Application.Interfaces;
 
 public interface IChatService
 {
-    Task SendMessageAsync(string user, string content, CancellationToken cancellationToken = default);
-    Task<IReadOnlyList<ChatMessage>> GetMessagesAsync(CancellationToken cancellationToken = default);
+    Task<Guid> StartConversationAsync(string user1, string user2, string topic, CancellationToken cancellationToken = default);
+    Task SendMessageAsync(Guid conversationId, string sender, string content, string? fileName = null, CancellationToken cancellationToken = default);
+    Task MarkDeliveredAsync(Guid id, CancellationToken cancellationToken = default);
+    Task MarkReadAsync(Guid id, CancellationToken cancellationToken = default);
+    Task UpdateMessageAsync(Guid id, string content, CancellationToken cancellationToken = default);
+    Task DeleteMessageAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ChatMessage?> GetMessageAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ChatMessage>> GetMessagesAsync(Guid conversationId, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ChatMessage>> SearchAsync(Guid conversationId, string term, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> GetFilesAsync(Guid conversationId, CancellationToken cancellationToken = default);
 }
 

--- a/Chattrix.Application/Interfaces/IUserService.cs
+++ b/Chattrix.Application/Interfaces/IUserService.cs
@@ -1,0 +1,12 @@
+using Chattrix.Core.Models;
+
+namespace Chattrix.Application.Interfaces;
+
+public interface IUserService
+{
+    Task SetStatusAsync(string user, string status, CancellationToken cancellationToken = default);
+    Task<string?> GetStatusAsync(string user, CancellationToken cancellationToken = default);
+    Task BlockAsync(string user, string blockedUser, CancellationToken cancellationToken = default);
+    Task UnblockAsync(string user, string blockedUser, CancellationToken cancellationToken = default);
+    Task<bool> IsBlockedAsync(string user, string otherUser, CancellationToken cancellationToken = default);
+}

--- a/Chattrix.Application/Services/ChatService.cs
+++ b/Chattrix.Application/Services/ChatService.cs
@@ -1,27 +1,89 @@
 using Chattrix.Application.Interfaces;
 using Chattrix.Core.Interfaces;
 using Chattrix.Core.Models;
+using System.Linq;
 
 namespace Chattrix.Application.Services;
 
 public class ChatService : IChatService
 {
-    private readonly IMessageRepository _repository;
+    private readonly IMessageRepository _messages;
+    private readonly IConversationRepository _conversations;
+    private readonly IUserService _users;
 
-    public ChatService(IMessageRepository repository)
+    public ChatService(IMessageRepository messages, IConversationRepository conversations, IUserService users)
     {
-        _repository = repository;
+        _messages = messages;
+        _conversations = conversations;
+        _users = users;
     }
 
-    public async Task SendMessageAsync(string user, string content, CancellationToken cancellationToken = default)
+    public async Task<Guid> StartConversationAsync(string user1, string user2, string topic, CancellationToken cancellationToken = default)
     {
-        var message = new ChatMessage(Guid.NewGuid(), user, content, DateTime.UtcNow);
-        await _repository.AddAsync(message, cancellationToken);
+        var conversation = new ChatConversation(Guid.NewGuid(), user1, user2, topic);
+        await _conversations.AddAsync(conversation, cancellationToken);
+        return conversation.Id;
     }
 
-    public Task<IReadOnlyList<ChatMessage>> GetMessagesAsync(CancellationToken cancellationToken = default)
+    public async Task SendMessageAsync(Guid conversationId, string sender, string content, string? fileName = null, CancellationToken cancellationToken = default)
     {
-        return _repository.GetAllAsync(cancellationToken);
+        var conversation = await _conversations.GetByIdAsync(conversationId, cancellationToken);
+        if (conversation is null) return;
+
+        var recipient = conversation.User1 == sender ? conversation.User2 : conversation.User1;
+        if (await _users.IsBlockedAsync(sender, recipient, cancellationToken)) return;
+
+        var message = new ChatMessage(Guid.NewGuid(), conversationId, sender, recipient, content, DateTime.UtcNow, fileName);
+        await _messages.AddAsync(message, cancellationToken);
+    }
+
+    public async Task MarkDeliveredAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var msg = await _messages.GetByIdAsync(id, cancellationToken);
+        if (msg is null) return;
+        await _messages.UpdateAsync(msg with { IsDelivered = true }, cancellationToken);
+    }
+
+    public async Task MarkReadAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var msg = await _messages.GetByIdAsync(id, cancellationToken);
+        if (msg is null) return;
+        await _messages.UpdateAsync(msg with { IsRead = true }, cancellationToken);
+    }
+
+    public async Task UpdateMessageAsync(Guid id, string content, CancellationToken cancellationToken = default)
+    {
+        var existing = await _messages.GetByIdAsync(id, cancellationToken);
+        if (existing is null) return;
+
+        var updated = existing with { Content = content, IsEdited = true };
+        await _messages.UpdateAsync(updated, cancellationToken);
+    }
+
+    public Task DeleteMessageAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _messages.DeleteAsync(id, cancellationToken);
+    }
+
+    public Task<ChatMessage?> GetMessageAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return _messages.GetByIdAsync(id, cancellationToken);
+    }
+
+    public Task<IReadOnlyList<ChatMessage>> GetMessagesAsync(Guid conversationId, CancellationToken cancellationToken = default)
+    {
+        return _messages.GetByConversationAsync(conversationId, cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ChatMessage>> SearchAsync(Guid conversationId, string term, CancellationToken cancellationToken = default)
+    {
+        var messages = await _messages.GetByConversationAsync(conversationId, cancellationToken);
+        return messages.Where(m => m.Content.Contains(term, StringComparison.OrdinalIgnoreCase)).ToList();
+    }
+
+    public async Task<IReadOnlyList<string>> GetFilesAsync(Guid conversationId, CancellationToken cancellationToken = default)
+    {
+        var messages = await _messages.GetByConversationAsync(conversationId, cancellationToken);
+        return messages.Where(m => m.FileName is not null).Select(m => m.FileName!).ToList();
     }
 }
-

--- a/Chattrix.Application/Services/UserService.cs
+++ b/Chattrix.Application/Services/UserService.cs
@@ -1,0 +1,48 @@
+using Chattrix.Application.Interfaces;
+using Chattrix.Core.Interfaces;
+using Chattrix.Core.Models;
+
+namespace Chattrix.Application.Services;
+
+public class UserService : IUserService
+{
+    private readonly IUserRepository _repository;
+
+    public UserService(IUserRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task SetStatusAsync(string user, string status, CancellationToken cancellationToken = default)
+    {
+        var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
+        profile.Status = status;
+        await _repository.UpdateAsync(profile, cancellationToken);
+    }
+
+    public async Task<string?> GetStatusAsync(string user, CancellationToken cancellationToken = default)
+    {
+        var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
+        return profile.Status;
+    }
+
+    public async Task BlockAsync(string user, string blockedUser, CancellationToken cancellationToken = default)
+    {
+        var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
+        profile.BlockedUsers.Add(blockedUser);
+        await _repository.UpdateAsync(profile, cancellationToken);
+    }
+
+    public async Task UnblockAsync(string user, string blockedUser, CancellationToken cancellationToken = default)
+    {
+        var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
+        profile.BlockedUsers.Remove(blockedUser);
+        await _repository.UpdateAsync(profile, cancellationToken);
+    }
+
+    public async Task<bool> IsBlockedAsync(string user, string otherUser, CancellationToken cancellationToken = default)
+    {
+        var profile = await _repository.GetOrCreateAsync(otherUser, cancellationToken);
+        return profile.BlockedUsers.Contains(user);
+    }
+}

--- a/Chattrix.Core/Interfaces/IConversationRepository.cs
+++ b/Chattrix.Core/Interfaces/IConversationRepository.cs
@@ -1,0 +1,10 @@
+using Chattrix.Core.Models;
+
+namespace Chattrix.Core.Interfaces;
+
+public interface IConversationRepository
+{
+    Task AddAsync(ChatConversation conversation, CancellationToken cancellationToken = default);
+    Task<ChatConversation?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ChatConversation>> GetByUsersAsync(string user1, string user2, CancellationToken cancellationToken = default);
+}

--- a/Chattrix.Core/Interfaces/IMessageRepository.cs
+++ b/Chattrix.Core/Interfaces/IMessageRepository.cs
@@ -5,6 +5,10 @@ namespace Chattrix.Core.Interfaces;
 public interface IMessageRepository
 {
     Task AddAsync(ChatMessage message, CancellationToken cancellationToken = default);
+    Task UpdateAsync(ChatMessage message, CancellationToken cancellationToken = default);
+    Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<ChatMessage?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<ChatMessage>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<ChatMessage>> GetByConversationAsync(Guid conversationId, CancellationToken cancellationToken = default);
 }
 

--- a/Chattrix.Core/Interfaces/IUserRepository.cs
+++ b/Chattrix.Core/Interfaces/IUserRepository.cs
@@ -1,0 +1,9 @@
+using Chattrix.Core.Models;
+
+namespace Chattrix.Core.Interfaces;
+
+public interface IUserRepository
+{
+    Task<UserProfile> GetOrCreateAsync(string user, CancellationToken cancellationToken = default);
+    Task UpdateAsync(UserProfile profile, CancellationToken cancellationToken = default);
+}

--- a/Chattrix.Core/Models/ChatConversation.cs
+++ b/Chattrix.Core/Models/ChatConversation.cs
@@ -1,0 +1,10 @@
+namespace Chattrix.Core.Models;
+
+/// <summary>
+/// Represents a chat conversation between two users with a specific topic.
+/// </summary>
+/// <param name="Id">Unique conversation identifier.</param>
+/// <param name="User1">First participant.</param>
+/// <param name="User2">Second participant.</param>
+/// <param name="Topic">Conversation topic.</param>
+public record ChatConversation(Guid Id, string User1, string User2, string Topic);

--- a/Chattrix.Core/Models/ChatMessage.cs
+++ b/Chattrix.Core/Models/ChatMessage.cs
@@ -1,4 +1,26 @@
 namespace Chattrix.Core.Models;
 
-public record ChatMessage(Guid Id, string User, string Content, DateTime Timestamp);
-
+/// <summary>
+/// Represents a single chat message.
+/// </summary>
+/// <param name="Id">Unique message identifier.</param>
+/// <param name="ConversationId">The conversation this message belongs to.</param>
+/// <param name="Sender">Sending user.</param>
+/// <param name="Recipient">Receiving user.</param>
+/// <param name="Content">Text content.</param>
+/// <param name="Timestamp">Creation time.</param>
+/// <param name="FileName">Optional file attachment name.</param>
+/// <param name="IsDelivered">Whether the message has been delivered.</param>
+/// <param name="IsRead">Whether the message has been read by the recipient.</param>
+/// <param name="IsEdited">Indicates whether the message has been edited.</param>
+public record ChatMessage(
+    Guid Id,
+    Guid ConversationId,
+    string Sender,
+    string Recipient,
+    string Content,
+    DateTime Timestamp,
+    string? FileName = null,
+    bool IsDelivered = false,
+    bool IsRead = false,
+    bool IsEdited = false);

--- a/Chattrix.Core/Models/UserProfile.cs
+++ b/Chattrix.Core/Models/UserProfile.cs
@@ -1,0 +1,16 @@
+namespace Chattrix.Core.Models;
+
+/// <summary>
+/// Basic user profile for status and block list management.
+/// </summary>
+public class UserProfile
+{
+    public string User { get; }
+    public string Status { get; set; } = string.Empty;
+    public HashSet<string> BlockedUsers { get; } = new();
+
+    public UserProfile(string user)
+    {
+        User = user;
+    }
+}

--- a/Chattrix.Infrastructure/DependencyInjection.cs
+++ b/Chattrix.Infrastructure/DependencyInjection.cs
@@ -9,6 +9,8 @@ public static class DependencyInjection
     public static IServiceCollection AddInfrastructure(this IServiceCollection services)
     {
         services.AddSingleton<IMessageRepository, InMemoryMessageRepository>();
+        services.AddSingleton<IConversationRepository, InMemoryConversationRepository>();
+        services.AddSingleton<IUserRepository, InMemoryUserRepository>();
         return services;
     }
 }

--- a/Chattrix.Infrastructure/Repositories/InMemoryConversationRepository.cs
+++ b/Chattrix.Infrastructure/Repositories/InMemoryConversationRepository.cs
@@ -1,0 +1,29 @@
+using Chattrix.Core.Interfaces;
+using Chattrix.Core.Models;
+using System.Linq;
+
+namespace Chattrix.Infrastructure.Repositories;
+
+public class InMemoryConversationRepository : IConversationRepository
+{
+    private readonly List<ChatConversation> _conversations = new();
+
+    public Task AddAsync(ChatConversation conversation, CancellationToken cancellationToken = default)
+    {
+        _conversations.Add(conversation);
+        return Task.CompletedTask;
+    }
+
+    public Task<ChatConversation?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var conversation = _conversations.FirstOrDefault(c => c.Id == id);
+        return Task.FromResult(conversation);
+    }
+
+    public Task<IReadOnlyList<ChatConversation>> GetByUsersAsync(string user1, string user2, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<ChatConversation> result = _conversations.Where(c =>
+            (c.User1 == user1 && c.User2 == user2) || (c.User1 == user2 && c.User2 == user1)).ToList();
+        return Task.FromResult(result);
+    }
+}

--- a/Chattrix.Infrastructure/Repositories/InMemoryMessageRepository.cs
+++ b/Chattrix.Infrastructure/Repositories/InMemoryMessageRepository.cs
@@ -1,5 +1,6 @@
 using Chattrix.Core.Interfaces;
 using Chattrix.Core.Models;
+using System.Linq;
 
 namespace Chattrix.Infrastructure.Repositories;
 
@@ -13,9 +14,37 @@ public class InMemoryMessageRepository : IMessageRepository
         return Task.CompletedTask;
     }
 
+    public Task UpdateAsync(ChatMessage message, CancellationToken cancellationToken = default)
+    {
+        var index = _messages.FindIndex(m => m.Id == message.Id);
+        if (index >= 0)
+        {
+            _messages[index] = message;
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        _messages.RemoveAll(m => m.Id == id);
+        return Task.CompletedTask;
+    }
+
+    public Task<ChatMessage?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var message = _messages.FirstOrDefault(m => m.Id == id);
+        return Task.FromResult(message);
+    }
+
     public Task<IReadOnlyList<ChatMessage>> GetAllAsync(CancellationToken cancellationToken = default)
     {
         IReadOnlyList<ChatMessage> result = _messages.ToList();
+        return Task.FromResult(result);
+    }
+
+    public Task<IReadOnlyList<ChatMessage>> GetByConversationAsync(Guid conversationId, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<ChatMessage> result = _messages.Where(m => m.ConversationId == conversationId).ToList();
         return Task.FromResult(result);
     }
 }

--- a/Chattrix.Infrastructure/Repositories/InMemoryUserRepository.cs
+++ b/Chattrix.Infrastructure/Repositories/InMemoryUserRepository.cs
@@ -1,0 +1,27 @@
+using Chattrix.Core.Interfaces;
+using Chattrix.Core.Models;
+using System.Collections.Generic;
+
+namespace Chattrix.Infrastructure.Repositories;
+
+public class InMemoryUserRepository : IUserRepository
+{
+    private readonly Dictionary<string, UserProfile> _users = new();
+
+    public Task<UserProfile> GetOrCreateAsync(string user, CancellationToken cancellationToken = default)
+    {
+        if (!_users.TryGetValue(user, out var profile))
+        {
+            profile = new UserProfile(user);
+            _users[user] = profile;
+        }
+
+        return Task.FromResult(profile);
+    }
+
+    public Task UpdateAsync(UserProfile profile, CancellationToken cancellationToken = default)
+    {
+        _users[profile.User] = profile;
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- expand `ChatMessage` model to track edits
- add update/delete operations in `IMessageRepository` and `IChatService`
- implement CRUD logic in `ChatService`
- expose new endpoints in `ChatController`
- expand in-memory repository to support update/delete/get by ID
- handle multiple conversations and user management

## Testing
- `dotnet build` *(fails: command not found)*