### PR TITLE
Add user status enum

### DIFF
--- a/Chattrix.Api/Controllers/UserController.cs
+++ b/Chattrix.Api/Controllers/UserController.cs
@@ -1,4 +1,5 @@
 using Chattrix.Application.Interfaces;
+using Chattrix.Core.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Chattrix.Api.Controllers;
@@ -15,14 +16,14 @@ public class UserController : ControllerBase
     }
 
     [HttpPost("status")] 
-    public async Task<IActionResult> SetStatus(string user, string status, CancellationToken cancellationToken)
+    public async Task<IActionResult> SetStatus(string user, UserStatus status, CancellationToken cancellationToken)
     {
         await _users.SetStatusAsync(user, status, cancellationToken);
         return NoContent();
     }
 
     [HttpGet("status/{user}")]
-    public Task<string?> GetStatus(string user, CancellationToken cancellationToken)
+    public Task<UserStatus> GetStatus(string user, CancellationToken cancellationToken)
     {
         return _users.GetStatusAsync(user, cancellationToken);
     }

--- a/Chattrix.Application/Interfaces/IUserService.cs
+++ b/Chattrix.Application/Interfaces/IUserService.cs
@@ -4,8 +4,8 @@ namespace Chattrix.Application.Interfaces;
 
 public interface IUserService
 {
-    Task SetStatusAsync(string user, string status, CancellationToken cancellationToken = default);
-    Task<string?> GetStatusAsync(string user, CancellationToken cancellationToken = default);
+    Task SetStatusAsync(string user, UserStatus status, CancellationToken cancellationToken = default);
+    Task<UserStatus> GetStatusAsync(string user, CancellationToken cancellationToken = default);
     Task BlockAsync(string user, string blockedUser, CancellationToken cancellationToken = default);
     Task UnblockAsync(string user, string blockedUser, CancellationToken cancellationToken = default);
     Task<bool> IsBlockedAsync(string user, string otherUser, CancellationToken cancellationToken = default);

--- a/Chattrix.Application/Services/UserService.cs
+++ b/Chattrix.Application/Services/UserService.cs
@@ -13,14 +13,14 @@ public class UserService : IUserService
         _repository = repository;
     }
 
-    public async Task SetStatusAsync(string user, string status, CancellationToken cancellationToken = default)
+    public async Task SetStatusAsync(string user, UserStatus status, CancellationToken cancellationToken = default)
     {
         var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
         profile.Status = status;
         await _repository.UpdateAsync(profile, cancellationToken);
     }
 
-    public async Task<string?> GetStatusAsync(string user, CancellationToken cancellationToken = default)
+    public async Task<UserStatus> GetStatusAsync(string user, CancellationToken cancellationToken = default)
     {
         var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
         return profile.Status;

--- a/Chattrix.Core/Models/UserProfile.cs
+++ b/Chattrix.Core/Models/UserProfile.cs
@@ -6,7 +6,7 @@ namespace Chattrix.Core.Models;
 public class UserProfile
 {
     public string User { get; }
-    public string Status { get; set; } = string.Empty;
+    public UserStatus Status { get; set; } = UserStatus.Available;
     public HashSet<string> BlockedUsers { get; } = new();
 
     public UserProfile(string user)

--- a/Chattrix.Core/Models/UserStatus.cs
+++ b/Chattrix.Core/Models/UserStatus.cs
@@ -1,0 +1,12 @@
+namespace Chattrix.Core.Models;
+
+/// <summary>
+/// Allowed user presence states.
+/// </summary>
+public enum UserStatus
+{
+    Available,
+    Busy,
+    Away,
+    Offline
+}


### PR DESCRIPTION
## Summary
- add `UserStatus` enum to represent allowed presence states
- store the enum in user profiles
- update UserService and UserController to work with `UserStatus`

## Testing
- `dotnet build --no-restore` *(fails: unable to load nuget packages)*