### PR TITLE
Restrict status updates to chat contacts

### DIFF
--- a/Chattrix.Api/Hubs/UserHub.cs
+++ b/Chattrix.Api/Hubs/UserHub.cs
@@ -1,17 +1,21 @@
 using Chattrix.Application.Interfaces;
+using Chattrix.Core.Interfaces;
 using Chattrix.Core.Models;
 using Microsoft.AspNetCore.SignalR;
 using System;
+using System.Linq;
 
 namespace Chattrix.Api.Hubs;
 
 public class UserHub : Hub
 {
     private readonly IUserService _users;
+    private readonly IConversationRepository _conversations;
 
-    public UserHub(IUserService users)
+    public UserHub(IUserService users, IConversationRepository conversations)
     {
         _users = users;
+        _conversations = conversations;
     }
 
     public override async Task OnConnectedAsync()
@@ -19,8 +23,9 @@ public class UserHub : Hub
         var user = Context.GetHttpContext()?.Request.Query["user"].ToString();
         if (!string.IsNullOrEmpty(user))
         {
+            await Groups.AddToGroupAsync(Context.ConnectionId, user);
             await _users.SetStatusAsync(user, UserStatus.Available);
-            await Clients.All.SendAsync("StatusChanged", user, UserStatus.Available);
+            await NotifyContactsAsync(user, UserStatus.Available);
         }
         await base.OnConnectedAsync();
     }
@@ -31,7 +36,7 @@ public class UserHub : Hub
         if (!string.IsNullOrEmpty(user))
         {
             await _users.SetStatusAsync(user, UserStatus.Offline);
-            await Clients.All.SendAsync("StatusChanged", user, UserStatus.Offline);
+            await NotifyContactsAsync(user, UserStatus.Offline);
         }
         await base.OnDisconnectedAsync(exception);
     }
@@ -39,7 +44,16 @@ public class UserHub : Hub
     public async Task UpdateStatus(string user, UserStatus status)
     {
         await _users.SetStatusAsync(user, status);
-        await Clients.All.SendAsync("StatusChanged", user, status);
+        await NotifyContactsAsync(user, status);
+    }
+
+    private async Task NotifyContactsAsync(string user, UserStatus status)
+    {
+        var contacts = await _conversations.GetContactsAsync(user);
+        foreach (var contact in contacts.Append(user))
+        {
+            await Clients.Group(contact).SendAsync("StatusChanged", user, status);
+        }
     }
 }
 

--- a/Chattrix.Core/Interfaces/IConversationRepository.cs
+++ b/Chattrix.Core/Interfaces/IConversationRepository.cs
@@ -7,4 +7,5 @@ public interface IConversationRepository
     Task AddAsync(ChatConversation conversation, CancellationToken cancellationToken = default);
     Task<ChatConversation?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<ChatConversation>> GetByUsersAsync(string user1, string user2, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<string>> GetContactsAsync(string user, CancellationToken cancellationToken = default);
 }

--- a/Chattrix.Infrastructure/Repositories/InMemoryConversationRepository.cs
+++ b/Chattrix.Infrastructure/Repositories/InMemoryConversationRepository.cs
@@ -26,4 +26,14 @@ public class InMemoryConversationRepository : IConversationRepository
             (c.User1 == user1 && c.User2 == user2) || (c.User1 == user2 && c.User2 == user1)).ToList();
         return Task.FromResult(result);
     }
+
+    public Task<IReadOnlyList<string>> GetContactsAsync(string user, CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<string> result = _conversations
+            .Where(c => c.User1 == user || c.User2 == user)
+            .Select(c => c.User1 == user ? c.User2 : c.User1)
+            .Distinct()
+            .ToList();
+        return Task.FromResult(result);
+    }
 }


### PR DESCRIPTION
## Summary
- add `GetContactsAsync` to conversation repository
- update the in-memory conversation repo to return unique contacts
- change `UserHub` to notify only conversation partners about status changes

## Testing
- `dotnet test` *(fails: Unable to restore packages due to missing network access)*