### PR TITLE
Use EF Core in-memory database

### DIFF
--- a/Chattrix.Infrastructure/Chattrix.Infrastructure.csproj
+++ b/Chattrix.Infrastructure/Chattrix.Infrastructure.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.5" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/Chattrix.Infrastructure/Data/ChatDbContext.cs
+++ b/Chattrix.Infrastructure/Data/ChatDbContext.cs
@@ -1,0 +1,105 @@
+using System.Text.Json;
+using Chattrix.Core.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Chattrix.Infrastructure.Data;
+
+public class ChatDbContext : DbContext
+{
+    public ChatDbContext(DbContextOptions<ChatDbContext> options) : base(options) { }
+
+    public DbSet<ChatMessageEntity> Messages => Set<ChatMessageEntity>();
+    public DbSet<ChatConversationEntity> Conversations => Set<ChatConversationEntity>();
+    public DbSet<UserProfileEntity> Users => Set<UserProfileEntity>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<ChatMessageEntity>().HasKey(m => m.Id);
+        modelBuilder.Entity<ChatConversationEntity>().HasKey(c => c.Id);
+        modelBuilder.Entity<UserProfileEntity>().HasKey(u => u.User);
+        modelBuilder.Entity<UserProfileEntity>()
+            .Property(u => u.Status)
+            .HasConversion<int>();
+    }
+}
+
+public class ChatMessageEntity
+{
+    public Guid Id { get; set; }
+    public Guid ConversationId { get; set; }
+    public string Sender { get; set; } = string.Empty;
+    public string Recipient { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; }
+    public string? FilesJson { get; set; }
+    public bool IsDelivered { get; set; }
+    public bool IsRead { get; set; }
+    public bool IsEdited { get; set; }
+
+    public ChatMessage ToModel()
+    {
+        var files = FilesJson is null ? null :
+            JsonSerializer.Deserialize<List<ChatAttachment>>(FilesJson);
+        return new ChatMessage(Id, ConversationId, Sender, Recipient, Content, Timestamp, files, IsDelivered, IsRead, IsEdited);
+    }
+
+    public static ChatMessageEntity FromModel(ChatMessage model)
+    {
+        return new ChatMessageEntity
+        {
+            Id = model.Id,
+            ConversationId = model.ConversationId,
+            Sender = model.Sender,
+            Recipient = model.Recipient,
+            Content = model.Content,
+            Timestamp = model.Timestamp,
+            FilesJson = model.Files is null ? null : JsonSerializer.Serialize(model.Files),
+            IsDelivered = model.IsDelivered,
+            IsRead = model.IsRead,
+            IsEdited = model.IsEdited
+        };
+    }
+}
+
+public class ChatConversationEntity
+{
+    public Guid Id { get; set; }
+    public string User1 { get; set; } = string.Empty;
+    public string User2 { get; set; } = string.Empty;
+    public string Topic { get; set; } = string.Empty;
+
+    public ChatConversation ToModel() => new(Id, User1, User2, Topic);
+
+    public static ChatConversationEntity FromModel(ChatConversation model) => new()
+    {
+        Id = model.Id,
+        User1 = model.User1,
+        User2 = model.User2,
+        Topic = model.Topic
+    };
+}
+
+public class UserProfileEntity
+{
+    public string User { get; set; } = string.Empty;
+    public UserStatus Status { get; set; } = UserStatus.Available;
+    public string BlockedUsersJson { get; set; } = "[]";
+
+    public UserProfile ToModel()
+    {
+        var profile = new UserProfile(User) { Status = Status };
+        var blocked = JsonSerializer.Deserialize<HashSet<string>>(BlockedUsersJson) ?? new HashSet<string>();
+        foreach (var b in blocked) profile.BlockedUsers.Add(b);
+        return profile;
+    }
+
+    public static UserProfileEntity FromModel(UserProfile model)
+    {
+        return new UserProfileEntity
+        {
+            User = model.User,
+            Status = model.Status,
+            BlockedUsersJson = JsonSerializer.Serialize(model.BlockedUsers)
+        };
+    }
+}

--- a/Chattrix.Infrastructure/DependencyInjection.cs
+++ b/Chattrix.Infrastructure/DependencyInjection.cs
@@ -1,8 +1,10 @@
 using Microsoft.Extensions.DependencyInjection;
 using Chattrix.Core.Interfaces;
 using Chattrix.Infrastructure.Repositories;
-using Chattrix.Application.Interfaces;
 using Chattrix.Infrastructure.Services;
+using Chattrix.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Chattrix.Application.Interfaces;
 
 namespace Chattrix.Infrastructure;
 
@@ -10,9 +12,10 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services)
     {
-        services.AddSingleton<IMessageRepository, InMemoryMessageRepository>();
-        services.AddSingleton<IConversationRepository, InMemoryConversationRepository>();
-        services.AddSingleton<IUserRepository, InMemoryUserRepository>();
+        services.AddDbContext<ChatDbContext>(options => options.UseInMemoryDatabase("ChatDb"));
+        services.AddScoped<IMessageRepository, DbMessageRepository>();
+        services.AddScoped<IConversationRepository, DbConversationRepository>();
+        services.AddScoped<IUserRepository, DbUserRepository>();
         services.AddSingleton<IEmailService, ConsoleEmailService>();
         return services;
     }

--- a/Chattrix.Infrastructure/Repositories/DbConversationRepository.cs
+++ b/Chattrix.Infrastructure/Repositories/DbConversationRepository.cs
@@ -1,0 +1,46 @@
+using Chattrix.Core.Interfaces;
+using Chattrix.Core.Models;
+using Chattrix.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace Chattrix.Infrastructure.Repositories;
+
+public class DbConversationRepository : IConversationRepository
+{
+    private readonly ChatDbContext _context;
+
+    public DbConversationRepository(ChatDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddAsync(ChatConversation conversation, CancellationToken cancellationToken = default)
+    {
+        _context.Conversations.Add(ChatConversationEntity.FromModel(conversation));
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<ChatConversation?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Conversations.AsNoTracking().FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+        return entity?.ToModel();
+    }
+
+    public async Task<IReadOnlyList<ChatConversation>> GetByUsersAsync(string user1, string user2, CancellationToken cancellationToken = default)
+    {
+        return await _context.Conversations.AsNoTracking()
+            .Where(c => (c.User1 == user1 && c.User2 == user2) || (c.User1 == user2 && c.User2 == user1))
+            .Select(c => c.ToModel())
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<string>> GetContactsAsync(string user, CancellationToken cancellationToken = default)
+    {
+        return await _context.Conversations.AsNoTracking()
+            .Where(c => c.User1 == user || c.User2 == user)
+            .Select(c => c.User1 == user ? c.User2 : c.User1)
+            .Distinct()
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Chattrix.Infrastructure/Repositories/DbMessageRepository.cs
+++ b/Chattrix.Infrastructure/Repositories/DbMessageRepository.cs
@@ -1,0 +1,58 @@
+using Chattrix.Core.Interfaces;
+using Chattrix.Core.Models;
+using Chattrix.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+
+namespace Chattrix.Infrastructure.Repositories;
+
+public class DbMessageRepository : IMessageRepository
+{
+    private readonly ChatDbContext _context;
+
+    public DbMessageRepository(ChatDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task AddAsync(ChatMessage message, CancellationToken cancellationToken = default)
+    {
+        _context.Messages.Add(ChatMessageEntity.FromModel(message));
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(ChatMessage message, CancellationToken cancellationToken = default)
+    {
+        _context.Messages.Update(ChatMessageEntity.FromModel(message));
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Messages.FindAsync([id], cancellationToken);
+        if (entity != null)
+        {
+            _context.Messages.Remove(entity);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    public async Task<ChatMessage?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Messages.AsNoTracking().FirstOrDefaultAsync(m => m.Id == id, cancellationToken);
+        return entity?.ToModel();
+    }
+
+    public async Task<IReadOnlyList<ChatMessage>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.Messages.AsNoTracking().Select(m => m.ToModel()).ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ChatMessage>> GetByConversationAsync(Guid conversationId, CancellationToken cancellationToken = default)
+    {
+        return await _context.Messages.AsNoTracking()
+            .Where(m => m.ConversationId == conversationId)
+            .Select(m => m.ToModel())
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Chattrix.Infrastructure/Repositories/DbUserRepository.cs
+++ b/Chattrix.Infrastructure/Repositories/DbUserRepository.cs
@@ -1,0 +1,34 @@
+using Chattrix.Core.Interfaces;
+using Chattrix.Core.Models;
+using Chattrix.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Chattrix.Infrastructure.Repositories;
+
+public class DbUserRepository : IUserRepository
+{
+    private readonly ChatDbContext _context;
+
+    public DbUserRepository(ChatDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<UserProfile> GetOrCreateAsync(string user, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.Users.FindAsync(new object[] { user }, cancellationToken);
+        if (entity == null)
+        {
+            entity = new UserProfileEntity { User = user };
+            _context.Users.Add(entity);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+        return entity.ToModel();
+    }
+
+    public async Task UpdateAsync(UserProfile profile, CancellationToken cancellationToken = default)
+    {
+        _context.Users.Update(UserProfileEntity.FromModel(profile));
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ChatDbContext` with EF Core entities
- implement repository classes that use `ChatDbContext`
- register EF Core context and repositories in DI
- switch Infrastructure project to use `Microsoft.EntityFrameworkCore.InMemory`

## Testing
- `dotnet build --no-restore --verbosity minimal` *(fails: project.assets.json not found)*