### PR TITLE
Add audio attachment support

### DIFF
--- a/Chattrix.Application/Services/ChatService.cs
+++ b/Chattrix.Application/Services/ChatService.cs
@@ -15,9 +15,11 @@ public class ChatService : IChatService
     private readonly IEmailService _emails;
     private readonly IBackgroundJobClient _jobs;
     private const int MaxFileSizeBytes = 5 * 1024 * 1024; // 5 MB default limit
+    // Allowed file types for attachments, including audio for voice messages
     private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
-        ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".txt"
+        ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".txt",
+        ".mp3", ".wav", ".ogg", ".m4a"
     };
 
     public ChatService(

--- a/Chattrix.Core/Models/ChatAttachment.cs
+++ b/Chattrix.Core/Models/ChatAttachment.cs
@@ -5,6 +5,7 @@ namespace Chattrix.Core.Models;
 /// <summary>
 /// Represents a file attachment in a chat message.
 /// Data should be a base64 encoded string containing the file bytes.
+/// Voice messages are also sent using this attachment model as audio files.
 /// </summary>
 /// <param name="FileName">Original file name including extension.</param>
 /// <param name="Data">Base64 encoded file data.</param>

--- a/Chattrix.Core/Models/ChatMessage.cs
+++ b/Chattrix.Core/Models/ChatMessage.cs
@@ -9,7 +9,7 @@ namespace Chattrix.Core.Models;
 /// <param name="Recipient">Receiving user.</param>
 /// <param name="Content">Text content.</param>
 /// <param name="Timestamp">Creation time.</param>
-/// <param name="Files">Optional file attachments.</param>
+/// <param name="Files">Optional file attachments including voice messages.</param>
 /// <param name="IsDelivered">Whether the message has been delivered.</param>
 /// <param name="IsRead">Whether the message has been read by the recipient.</param>
 /// <param name="IsEdited">Indicates whether the message has been edited.</param>


### PR DESCRIPTION
## Summary
- allow audio file types for chat attachments
- document that attachments are also used for voice messages

## Testing
- `dotnet build --no-restore` *(fails: project.assets.json not found)*
- `dotnet restore` *(fails: unable to load source - no route to host)*