### PR TITLE
Refactor conversation fields to use IDs with original names

### DIFF
--- a/Chattrix.Application/Services/UserService.cs
+++ b/Chattrix.Application/Services/UserService.cs
@@ -29,20 +29,20 @@ public class UserService : IUserService
     public async Task BlockAsync(string user, string blockedUser, CancellationToken cancellationToken = default)
     {
         var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
-        profile.BlockedUsers.Add(blockedUser);
+        profile.BlockedUserIds.Add(blockedUser);
         await _repository.UpdateAsync(profile, cancellationToken);
     }
 
     public async Task UnblockAsync(string user, string blockedUser, CancellationToken cancellationToken = default)
     {
         var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
-        profile.BlockedUsers.Remove(blockedUser);
+        profile.BlockedUserIds.Remove(blockedUser);
         await _repository.UpdateAsync(profile, cancellationToken);
     }
 
     public async Task<bool> IsBlockedAsync(string user, string otherUser, CancellationToken cancellationToken = default)
     {
         var profile = await _repository.GetOrCreateAsync(otherUser, cancellationToken);
-        return profile.BlockedUsers.Contains(user);
+        return profile.BlockedUserIds.Contains(user);
     }
 }

--- a/Chattrix.Core/Models/ChatConversation.cs
+++ b/Chattrix.Core/Models/ChatConversation.cs
@@ -4,7 +4,7 @@ namespace Chattrix.Core.Models;
 /// Represents a chat conversation between two users with a specific topic.
 /// </summary>
 /// <param name="Id">Unique conversation identifier.</param>
-/// <param name="User1">First participant.</param>
-/// <param name="User2">Second participant.</param>
+/// <param name="User1">First participant user ID.</param>
+/// <param name="User2">Second participant user ID.</param>
 /// <param name="Topic">Conversation topic.</param>
 public record ChatConversation(Guid Id, string User1, string User2, string Topic);

--- a/Chattrix.Core/Models/UserProfile.cs
+++ b/Chattrix.Core/Models/UserProfile.cs
@@ -7,7 +7,7 @@ public class UserProfile
 {
     public string User { get; }
     public UserStatus Status { get; set; } = UserStatus.Available;
-    public HashSet<string> BlockedUsers { get; } = new();
+    public HashSet<string> BlockedUserIds { get; } = new();
 
     public UserProfile(string user)
     {

--- a/Chattrix.Infrastructure/Data/ChatDbContext.cs
+++ b/Chattrix.Infrastructure/Data/ChatDbContext.cs
@@ -89,7 +89,7 @@ public class UserProfileEntity
     {
         var profile = new UserProfile(User) { Status = Status };
         var blocked = JsonSerializer.Deserialize<HashSet<string>>(BlockedUsersJson) ?? new HashSet<string>();
-        foreach (var b in blocked) profile.BlockedUsers.Add(b);
+        foreach (var b in blocked) profile.BlockedUserIds.Add(b);
         return profile;
     }
 
@@ -99,7 +99,7 @@ public class UserProfileEntity
         {
             User = model.User,
             Status = model.Status,
-            BlockedUsersJson = JsonSerializer.Serialize(model.BlockedUsers)
+            BlockedUsersJson = JsonSerializer.Serialize(model.BlockedUserIds)
         };
     }
 }


### PR DESCRIPTION
## Summary
- revert participant fields to `User1` and `User2`
- update repositories and services to use these ID fields
- adjust API start endpoint and interfaces accordingly

## Testing
- `dotnet restore` *(fails: `dotnet` not found)*
- `dotnet build --no-restore` *(not run: `dotnet` not found)*