### PR TITLE
Refactor infrastructure entities

### DIFF
--- a/Chattrix.Infrastructure/Data/ChatDbContext.cs
+++ b/Chattrix.Infrastructure/Data/ChatDbContext.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Chattrix.Core.Models;
 using Microsoft.EntityFrameworkCore;
 
@@ -20,86 +19,5 @@ public class ChatDbContext : DbContext
         modelBuilder.Entity<UserProfileEntity>()
             .Property(u => u.Status)
             .HasConversion<int>();
-    }
-}
-
-public class ChatMessageEntity
-{
-    public Guid Id { get; set; }
-    public Guid ConversationId { get; set; }
-    public string Sender { get; set; } = string.Empty;
-    public string Recipient { get; set; } = string.Empty;
-    public string Content { get; set; } = string.Empty;
-    public DateTime Timestamp { get; set; }
-    public string? FilesJson { get; set; }
-    public bool IsDelivered { get; set; }
-    public bool IsRead { get; set; }
-    public bool IsEdited { get; set; }
-
-    public ChatMessage ToModel()
-    {
-        var files = FilesJson is null ? null :
-            JsonSerializer.Deserialize<List<ChatAttachment>>(FilesJson);
-        return new ChatMessage(Id, ConversationId, Sender, Recipient, Content, Timestamp, files, IsDelivered, IsRead, IsEdited);
-    }
-
-    public static ChatMessageEntity FromModel(ChatMessage model)
-    {
-        return new ChatMessageEntity
-        {
-            Id = model.Id,
-            ConversationId = model.ConversationId,
-            Sender = model.Sender,
-            Recipient = model.Recipient,
-            Content = model.Content,
-            Timestamp = model.Timestamp,
-            FilesJson = model.Files is null ? null : JsonSerializer.Serialize(model.Files),
-            IsDelivered = model.IsDelivered,
-            IsRead = model.IsRead,
-            IsEdited = model.IsEdited
-        };
-    }
-}
-
-public class ChatConversationEntity
-{
-    public Guid Id { get; set; }
-    public string User1 { get; set; } = string.Empty;
-    public string User2 { get; set; } = string.Empty;
-    public string Topic { get; set; } = string.Empty;
-
-    public ChatConversation ToModel() => new(Id, User1, User2, Topic);
-
-    public static ChatConversationEntity FromModel(ChatConversation model) => new()
-    {
-        Id = model.Id,
-        User1 = model.User1,
-        User2 = model.User2,
-        Topic = model.Topic
-    };
-}
-
-public class UserProfileEntity
-{
-    public string User { get; set; } = string.Empty;
-    public UserStatus Status { get; set; } = UserStatus.Available;
-    public string BlockedUsersJson { get; set; } = "[]";
-
-    public UserProfile ToModel()
-    {
-        var profile = new UserProfile(User) { Status = Status };
-        var blocked = JsonSerializer.Deserialize<HashSet<string>>(BlockedUsersJson) ?? new HashSet<string>();
-        foreach (var b in blocked) profile.BlockedUserIds.Add(b);
-        return profile;
-    }
-
-    public static UserProfileEntity FromModel(UserProfile model)
-    {
-        return new UserProfileEntity
-        {
-            User = model.User,
-            Status = model.Status,
-            BlockedUsersJson = JsonSerializer.Serialize(model.BlockedUserIds)
-        };
     }
 }

--- a/Chattrix.Infrastructure/Data/Entities/ChatConversationEntity.cs
+++ b/Chattrix.Infrastructure/Data/Entities/ChatConversationEntity.cs
@@ -1,0 +1,22 @@
+using System;
+using Chattrix.Core.Models;
+
+namespace Chattrix.Infrastructure.Data;
+
+public class ChatConversationEntity
+{
+    public Guid Id { get; set; }
+    public string User1 { get; set; } = string.Empty;
+    public string User2 { get; set; } = string.Empty;
+    public string Topic { get; set; } = string.Empty;
+
+    public ChatConversation ToModel() => new(Id, User1, User2, Topic);
+
+    public static ChatConversationEntity FromModel(ChatConversation model) => new()
+    {
+        Id = model.Id,
+        User1 = model.User1,
+        User2 = model.User2,
+        Topic = model.Topic
+    };
+}

--- a/Chattrix.Infrastructure/Data/Entities/ChatMessageEntity.cs
+++ b/Chattrix.Infrastructure/Data/Entities/ChatMessageEntity.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Chattrix.Core.Models;
+
+namespace Chattrix.Infrastructure.Data;
+
+public class ChatMessageEntity
+{
+    public Guid Id { get; set; }
+    public Guid ConversationId { get; set; }
+    public string Sender { get; set; } = string.Empty;
+    public string Recipient { get; set; } = string.Empty;
+    public string Content { get; set; } = string.Empty;
+    public DateTime Timestamp { get; set; }
+    public string? FilesJson { get; set; }
+    public bool IsDelivered { get; set; }
+    public bool IsRead { get; set; }
+    public bool IsEdited { get; set; }
+
+    public ChatMessage ToModel()
+    {
+        var files = FilesJson is null ? null :
+            JsonSerializer.Deserialize<List<ChatAttachment>>(FilesJson);
+        return new ChatMessage(Id, ConversationId, Sender, Recipient, Content, Timestamp, files, IsDelivered, IsRead, IsEdited);
+    }
+
+    public static ChatMessageEntity FromModel(ChatMessage model)
+    {
+        return new ChatMessageEntity
+        {
+            Id = model.Id,
+            ConversationId = model.ConversationId,
+            Sender = model.Sender,
+            Recipient = model.Recipient,
+            Content = model.Content,
+            Timestamp = model.Timestamp,
+            FilesJson = model.Files is null ? null : JsonSerializer.Serialize(model.Files),
+            IsDelivered = model.IsDelivered,
+            IsRead = model.IsRead,
+            IsEdited = model.IsEdited
+        };
+    }
+}

--- a/Chattrix.Infrastructure/Data/Entities/UserProfileEntity.cs
+++ b/Chattrix.Infrastructure/Data/Entities/UserProfileEntity.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using Chattrix.Core.Models;
+
+namespace Chattrix.Infrastructure.Data;
+
+public class UserProfileEntity
+{
+    public string User { get; set; } = string.Empty;
+    public UserStatus Status { get; set; } = UserStatus.Available;
+    public string BlockedUsersJson { get; set; } = "[]";
+
+    public UserProfile ToModel()
+    {
+        var profile = new UserProfile(User) { Status = Status };
+        var blocked = JsonSerializer.Deserialize<HashSet<string>>(BlockedUsersJson) ?? new HashSet<string>();
+        foreach (var b in blocked) profile.BlockedUserIds.Add(b);
+        return profile;
+    }
+
+    public static UserProfileEntity FromModel(UserProfile model)
+    {
+        return new UserProfileEntity
+        {
+            User = model.User,
+            Status = model.Status,
+            BlockedUsersJson = JsonSerializer.Serialize(model.BlockedUserIds)
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- move EF entities into dedicated files under `Infrastructure`
- trim `ChatDbContext` to hold only the DbContext implementation

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*