### PR TITLE
Decouple SignalR using domain events

### DIFF
--- a/Chattrix.Api/Controllers/UserController.cs
+++ b/Chattrix.Api/Controllers/UserController.cs
@@ -1,8 +1,6 @@
 using Chattrix.Application.Interfaces;
 using Chattrix.Core.Models;
-using Chattrix.Api.Hubs;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.SignalR;
 
 namespace Chattrix.Api.Controllers;
 
@@ -11,19 +9,16 @@ namespace Chattrix.Api.Controllers;
 public class UserController : ControllerBase
 {
     private readonly IUserService _users;
-    private readonly IHubContext<UserHub> _hub;
 
-    public UserController(IUserService users, IHubContext<UserHub> hub)
+    public UserController(IUserService users)
     {
         _users = users;
-        _hub = hub;
     }
 
     [HttpPost("status")] 
     public async Task<IActionResult> SetStatus(string user, UserStatus status, CancellationToken cancellationToken)
     {
         await _users.SetStatusAsync(user, status, cancellationToken);
-        await _hub.Clients.All.SendAsync("StatusChanged", user, status, cancellationToken);
         return NoContent();
     }
 

--- a/Chattrix.Api/Events/BroadcastChatMessageHandler.cs
+++ b/Chattrix.Api/Events/BroadcastChatMessageHandler.cs
@@ -1,0 +1,22 @@
+using Chattrix.Core.Events;
+using Chattrix.Api.Hubs;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Chattrix.Api.Events;
+
+public class BroadcastChatMessageHandler : IDomainEventHandler<ChatMessageSentEvent>
+{
+    private readonly IHubContext<ChatHub> _hub;
+
+    public BroadcastChatMessageHandler(IHubContext<ChatHub> hub)
+    {
+        _hub = hub;
+    }
+
+    public Task HandleAsync(ChatMessageSentEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        var msg = domainEvent.Message;
+        return _hub.Clients.Group(msg.ConversationId.ToString())
+            .SendAsync("ReceiveMessage", msg.ConversationId, msg.Sender, msg.Content, msg.Files, cancellationToken);
+    }
+}

--- a/Chattrix.Api/Events/BroadcastUserStatusChangedHandler.cs
+++ b/Chattrix.Api/Events/BroadcastUserStatusChangedHandler.cs
@@ -1,0 +1,28 @@
+using Chattrix.Core.Events;
+using Chattrix.Api.Hubs;
+using Chattrix.Core.Interfaces;
+using Microsoft.AspNetCore.SignalR;
+using System.Linq;
+
+namespace Chattrix.Api.Events;
+
+public class BroadcastUserStatusChangedHandler : IDomainEventHandler<UserStatusChangedEvent>
+{
+    private readonly IHubContext<UserHub> _hub;
+    private readonly IConversationRepository _conversations;
+
+    public BroadcastUserStatusChangedHandler(IHubContext<UserHub> hub, IConversationRepository conversations)
+    {
+        _hub = hub;
+        _conversations = conversations;
+    }
+
+    public async Task HandleAsync(UserStatusChangedEvent domainEvent, CancellationToken cancellationToken = default)
+    {
+        var contacts = await _conversations.GetContactsAsync(domainEvent.User, cancellationToken);
+        foreach (var contact in contacts.Append(domainEvent.User))
+        {
+            await _hub.Clients.Group(contact).SendAsync("StatusChanged", domainEvent.User, domainEvent.Status, cancellationToken);
+        }
+    }
+}

--- a/Chattrix.Api/Hubs/ChatHub.cs
+++ b/Chattrix.Api/Hubs/ChatHub.cs
@@ -19,10 +19,8 @@ public class ChatHub : Hub
         return Groups.AddToGroupAsync(Context.ConnectionId, conversationId.ToString());
     }
 
-    public async Task SendMessage(Guid conversationId, string sender, string content, IReadOnlyList<ChatAttachment>? files)
+    public Task SendMessage(Guid conversationId, string sender, string content, IReadOnlyList<ChatAttachment>? files)
     {
-        await _chatService.SendMessageAsync(conversationId, sender, content, files);
-        await Clients.Group(conversationId.ToString())
-            .SendAsync("ReceiveMessage", conversationId, sender, content, files);
+        return _chatService.SendMessageAsync(conversationId, sender, content, files);
     }
 }

--- a/Chattrix.Api/Hubs/UserHub.cs
+++ b/Chattrix.Api/Hubs/UserHub.cs
@@ -1,21 +1,17 @@
 using Chattrix.Application.Interfaces;
-using Chattrix.Core.Interfaces;
 using Chattrix.Core.Models;
 using Microsoft.AspNetCore.SignalR;
 using System;
-using System.Linq;
 
 namespace Chattrix.Api.Hubs;
 
 public class UserHub : Hub
 {
     private readonly IUserService _users;
-    private readonly IConversationRepository _conversations;
 
-    public UserHub(IUserService users, IConversationRepository conversations)
+    public UserHub(IUserService users)
     {
         _users = users;
-        _conversations = conversations;
     }
 
     public override async Task OnConnectedAsync()
@@ -25,7 +21,6 @@ public class UserHub : Hub
         {
             await Groups.AddToGroupAsync(Context.ConnectionId, user);
             await _users.SetStatusAsync(user, UserStatus.Available);
-            await NotifyContactsAsync(user, UserStatus.Available);
         }
         await base.OnConnectedAsync();
     }
@@ -36,7 +31,6 @@ public class UserHub : Hub
         if (!string.IsNullOrEmpty(user))
         {
             await _users.SetStatusAsync(user, UserStatus.Offline);
-            await NotifyContactsAsync(user, UserStatus.Offline);
         }
         await base.OnDisconnectedAsync(exception);
     }
@@ -44,16 +38,6 @@ public class UserHub : Hub
     public async Task UpdateStatus(string user, UserStatus status)
     {
         await _users.SetStatusAsync(user, status);
-        await NotifyContactsAsync(user, status);
-    }
-
-    private async Task NotifyContactsAsync(string user, UserStatus status)
-    {
-        var contacts = await _conversations.GetContactsAsync(user);
-        foreach (var contact in contacts.Append(user))
-        {
-            await Clients.Group(contact).SendAsync("StatusChanged", user, status);
-        }
     }
 }
 

--- a/Chattrix.Api/Program.cs
+++ b/Chattrix.Api/Program.cs
@@ -3,6 +3,7 @@ using Chattrix.Infrastructure;
 using Chattrix.Core.Events;
 using Chattrix.Api.Hubs;
 using Serilog;
+using Chattrix.Api.Events;
 using Hangfire;
 using Hangfire.MemoryStorage;
 
@@ -14,6 +15,8 @@ builder.Services.AddControllers();
 builder.Services.AddSignalR();
 builder.Services.AddHangfire(config => config.UseMemoryStorage());
 builder.Services.AddHangfireServer();
+builder.Services.AddScoped<IDomainEventHandler<ChatMessageSentEvent>, BroadcastChatMessageHandler>();
+builder.Services.AddScoped<IDomainEventHandler<UserStatusChangedEvent>, BroadcastUserStatusChangedHandler>();
 
 builder.Host.UseSerilog((ctx, cfg) => cfg.ReadFrom.Configuration(ctx.Configuration));
 

--- a/Chattrix.Application/Services/UserService.cs
+++ b/Chattrix.Application/Services/UserService.cs
@@ -1,6 +1,7 @@
 using Chattrix.Application.Interfaces;
 using Chattrix.Core.Interfaces;
 using Chattrix.Core.Models;
+using Chattrix.Core.Events;
 
 namespace Chattrix.Application.Services;
 
@@ -18,6 +19,7 @@ public class UserService : IUserService
         var profile = await _repository.GetOrCreateAsync(user, cancellationToken);
         profile.Status = status;
         await _repository.UpdateAsync(profile, cancellationToken);
+        await DomainEvents.RaiseAsync(new UserStatusChangedEvent(user, status), cancellationToken);
     }
 
     public async Task<UserStatus> GetStatusAsync(string user, CancellationToken cancellationToken = default)

--- a/Chattrix.Core/Events/UserStatusChangedEvent.cs
+++ b/Chattrix.Core/Events/UserStatusChangedEvent.cs
@@ -1,0 +1,8 @@
+using Chattrix.Core.Models;
+
+namespace Chattrix.Core.Events;
+
+public record UserStatusChangedEvent(string User, UserStatus Status) : IDomainEvent
+{
+    public DateTime OccurredOn { get; } = DateTime.UtcNow;
+}


### PR DESCRIPTION
## Summary
- broadcast chat messages and status updates via domain events
- notify contacts when user status changes
- update SignalR hubs and controllers to rely on the events

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*