### PR TITLE
Fix chat frontend root and recipient input

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -5,6 +5,7 @@
   "projects": {
     "chat-frontend": {
       "projectType": "application",
+      "root": "",
       "sourceRoot": "src",
       "prefix": "app",
       "architect": {

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -1,8 +1,18 @@
 <h1>{{ title }}</h1>
-<div class="chat-window">
-  <div *ngFor="let message of messages">
-    <strong>{{ message.sender }}:</strong> {{ message.content }}
-  </div>
+
+<div *ngIf="!conversationId">
+  <input [(ngModel)]="user" placeholder="Your username" />
+  <input [(ngModel)]="recipient" placeholder="Recipient" />
+  <input [(ngModel)]="topic" placeholder="Topic" />
+  <button (click)="startConversation()">Start</button>
 </div>
-<input [(ngModel)]="newMessage" placeholder="Type a message..." />
-<button (click)="send()">Send</button>
+
+<div *ngIf="conversationId">
+  <div class="chat-window">
+    <div *ngFor="let message of messages">
+      <strong>{{ message.sender }}:</strong> {{ message.content }}
+    </div>
+  </div>
+  <input [(ngModel)]="newMessage" placeholder="Type a message..." />
+  <button (click)="send()">Send</button>
+</div>

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 import { ChatService, ChatMessage } from './chat.service';
 
 @Component({
@@ -6,18 +6,19 @@ import { ChatService, ChatMessage } from './chat.service';
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent implements OnInit {
+export class AppComponent {
   title = 'Chat Frontend';
   conversationId: string | null = null;
-  user = 'alice';
-  recipient = 'bob';
-  topic = 'general';
+  user = '';
+  recipient = '';
+  topic = '';
   messages: ChatMessage[] = [];
   newMessage = '';
 
   constructor(private chat: ChatService) {}
 
-  ngOnInit(): void {
+  startConversation(): void {
+    if (!this.user.trim() || !this.recipient.trim() || !this.topic.trim()) return;
     this.chat.startConversation(this.user, this.recipient, this.topic)
       .subscribe(id => {
         this.conversationId = id;


### PR DESCRIPTION
## Summary
- fix missing `root` property in Angular workspace
- allow users to pick sender, recipient and topic before starting a conversation

## Testing
- `dotnet test` *(fails: `dotnet` not found)*
- `npm test` *(fails: missing script)*