### PR TITLE
Add file attachment support to chat frontend

### DIFF
--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -18,8 +18,23 @@
   <div class="chat-window">
     <div *ngFor="let message of messages">
       <strong>{{ message.sender }}:</strong> {{ message.content }}
+      <div *ngIf="message.files?.length">
+        <div *ngFor="let file of message.files">
+          <a
+            [href]="'data:application/octet-stream;base64,' + file.data"
+            [download]="file.fileName"
+            >{{ file.fileName }}</a
+          >
+        </div>
+      </div>
     </div>
   </div>
+
+  <input type="file" multiple (change)="onFileSelected($event)" />
+  <ul *ngIf="attachments.length">
+    <li *ngFor="let file of attachments">{{ file.fileName }}</li>
+  </ul>
+
   <input [(ngModel)]="newMessage" placeholder="Type a message..." />
   <button (click)="send()">Send</button>
 </div>

--- a/frontend/src/app/app.component.spec.ts
+++ b/frontend/src/app/app.component.spec.ts
@@ -14,16 +14,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'chattrix-frontend--no-routing' title`, () => {
+  it(`should have the 'Chat Frontend' title`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('chattrix-frontend--no-routing');
+    expect(app.title).toEqual('Chat Frontend');
   });
 
   it('should render title', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, chattrix-frontend--no-routing');
+    expect(compiled.querySelector('h1')?.textContent).toContain('Chat Frontend');
   });
 });


### PR DESCRIPTION
## Summary
- enable file attachments in messages
- handle file selection and convert to base64
- display selected attachments and sent files
- update unit tests for new title

## Testing
- `npm test` *(fails: ng not found)*