### PR TITLE
Add voice attachment support

### DIFF
--- a/Chattrix.Application/Services/ChatService.cs
+++ b/Chattrix.Application/Services/ChatService.cs
@@ -20,7 +20,7 @@ public class ChatService : IChatService
     private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
     {
         ".png", ".jpg", ".jpeg", ".gif", ".pdf", ".txt",
-        ".mp3", ".wav", ".ogg", ".m4a"
+        ".mp3", ".wav", ".ogg", ".m4a", ".webm"
     };
 
     public ChatService(

--- a/frontend/src/app/app.component.html
+++ b/frontend/src/app/app.component.html
@@ -20,11 +20,10 @@
       <strong>{{ message.sender }}:</strong> {{ message.content }}
       <div *ngIf="message.files?.length">
         <div *ngFor="let file of message.files">
-          <a
-            [href]="'data:application/octet-stream;base64,' + file.data"
-            [download]="file.fileName"
-            >{{ file.fileName }}</a
-          >
+          <audio *ngIf="isAudio(file)" controls [src]="getFileUrl(file)"></audio>
+          <a *ngIf="!isAudio(file)"
+            [href]="getFileUrl(file)"
+            [download]="file.fileName">{{ file.fileName }}</a>
         </div>
       </div>
     </div>
@@ -32,8 +31,13 @@
 
   <input type="file" multiple (change)="onFileSelected($event)" />
   <ul *ngIf="attachments.length">
-    <li *ngFor="let file of attachments">{{ file.fileName }}</li>
+    <li *ngFor="let file of attachments">
+      <audio *ngIf="isAudio(file)" controls [src]="getFileUrl(file)"></audio>
+      <span *ngIf="!isAudio(file)">{{ file.fileName }}</span>
+    </li>
   </ul>
+  <button *ngIf="!isRecording" (click)="startRecording()">Record voice</button>
+  <button *ngIf="isRecording" (click)="stopRecording()">Stop</button>
 
   <input [(ngModel)]="newMessage" placeholder="Type a message..." />
   <button (click)="send()">Send</button>


### PR DESCRIPTION
## Summary
- allow server to accept `.webm` voice files
- confirm frontend recording and attachment handling

## Testing
- `npm test` *(fails: package.json missing or ng not found)*
- `dotnet test` *(fails: command not found)*
